### PR TITLE
Fix the behavior of getPath when the 2nd arg is an empty obj and the 3rd arg is an obj of query params.

### DIFF
--- a/__tests__/pathManager.test.ts
+++ b/__tests__/pathManager.test.ts
@@ -15,18 +15,28 @@ describe('pathManager without the base url test', () => {
     expect(getPath('example', { exampleId: '1', slug: 'abc' })).toBe('/example/1/abc');
   });
 
-  it('getPath() returns a valid path if unnecessary parameters were provided.', () => {
+  it('getPath() returns a valid path if unnecessary route parameters are provided.', () => {
     expect(getPath('noParams', { param1: 'a', param2: 'b' })).toBe('/no-params');
+  });
+
+  it('getPath() returns a valid path if unnecessary route parameters and empty query params object are provided.', () => {
+    expect(getPath('noParams', { param1: 'a', param2: 'b' }, {})).toBe('/no-params');
   });
 
   it('getPath() returns the path with query parameters if an object is provided as 3rd argument.', () => {
     expect(getPath('example', { exampleId: '1', slug: 'abc' }, { page: '1', type: 'fire' })).toBe('/example/1/abc/?page=1&type=fire');
   });
 
+  it('getPath() returns the path with query parameters if an empty object is provided as the 2nd argument and an object of query parameters is provided as the 3rd argument.', () => {
+    expect(getPath('noParams', {}, { page: '1', type: 'fire' })).toBe('/no-params/?page=1&type=fire');
+  });
+
   it('getPath() throws Error if required parameters are missing.', () => {
     expect(() => getPath('example')).toThrow(missingRequiredParametersMsg('example', nameAndPathMap.example));
 
     expect(() => getPath('example', { slug: 'abc' })).toThrow(missingRequiredParametersMsg('example', nameAndPathMap.example));
+
+    expect(() => getPath('example', {}, { page: '1', type: 'fire' })).toThrow(missingRequiredParametersMsg('example', nameAndPathMap.example));
   });
 
   it('getPath() throws Error if invalid parameters were provided.', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "path-kanri",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A utility module for managing paths.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/methods/index.ts
+++ b/src/methods/index.ts
@@ -84,9 +84,15 @@ const pathManager = <TPathNameAndUriMap extends { [s: string]: unknown; }>(
    *
    * @param {string} path
    * @param {Record<string, string>} queryParams
-   * @return {*}  {string}
+   * @return {string} ex) isQueryParamsEmpty ? '/example' : '/example?page=1&limit=5'
    */
-  const withQueryParams = (path: string, queryParams: Record<string, string>): string => `${path}/?${generateQueryParamsStr(queryParams)}`;
+  const withQueryParams = (path: string, queryParams: Record<string, string>): string => {
+    const isQueryParamsEmpty = Object.keys(queryParams).length === 0;
+
+    return isQueryParamsEmpty
+      ? path
+      : `${path}/?${generateQueryParamsStr(queryParams)}`;
+  };
 
   /**
    * Get path
@@ -108,7 +114,11 @@ const pathManager = <TPathNameAndUriMap extends { [s: string]: unknown; }>(
     const rawUriStr = String(rawUri); // This is just for type conversion
 
     // Return if the path doesn't contain any parameter placeholder
-    if (!paramNames.length) return withBaseUrl(rawUriStr);
+    if (!paramNames.length) {
+      return queryParams
+        ? withQueryParams(rawUriStr, queryParams)
+        : withBaseUrl(rawUriStr);
+    }
 
     // The path contains parameter placeholders but params doesn't provided as the 2nd argument
     if (!params) {


### PR DESCRIPTION
# Overview
#1 

Fix the bug in getPath.
When query params are given with empty 2nd param, it returned the path without query params. Now fixed.

# Changes
withQueryParams in pathManager

# Affected scope
src/methods/index.ts

# Note
