### PR TITLE
Fix getFullPath bug

### DIFF
--- a/__tests__/pathManager.test.ts
+++ b/__tests__/pathManager.test.ts
@@ -10,56 +10,123 @@ const nameAndPathMap = {
 
 const { getPath, getFullPath } = pathManager(nameAndPathMap);
 
+// Tests without base url
 describe('pathManager without the base url test', () => {
-  it('getPath() can get a path by name and returns it with given parameters.', () => {
-    expect(getPath('example', { exampleId: '1', slug: 'abc' })).toBe('/example/1/abc');
+  it('getPath() can get the path by name and returns it with given parameters.', () => {
+    expect(getPath('example', { exampleId: '1', slug: 'abc' }))
+      .toBe('/example/1/abc');
   });
 
-  it('getPath() returns a valid path if unnecessary route parameters are provided.', () => {
-    expect(getPath('noParams', { param1: 'a', param2: 'b' })).toBe('/no-params');
+  it('getPath() returns the valid path if unnecessary route parameters are provided.', () => {
+    expect(getPath('noParams', { param1: 'a', param2: 'b' }))
+      .toBe('/no-params');
   });
 
-  it('getPath() returns a valid path if unnecessary route parameters and empty query params object are provided.', () => {
-    expect(getPath('noParams', { param1: 'a', param2: 'b' }, {})).toBe('/no-params');
+  it('getPath() returns the valid path if unnecessary route parameters and empty query params object are provided.', () => {
+    expect(getPath('noParams', { param1: 'a', param2: 'b' }, {}))
+      .toBe('/no-params');
+  });
+
+  it('getPath() returns the valid path if unnecessary route parameters when query params are provided.', () => {
+    expect(getPath('noParams', { param1: 'a', param2: 'b' }, { param1: 'a', param2: 'b' }))
+      .toBe('/no-params/?param1=a&param2=b');
   });
 
   it('getPath() returns the path with query parameters if an object is provided as 3rd argument.', () => {
-    expect(getPath('example', { exampleId: '1', slug: 'abc' }, { page: '1', type: 'fire' })).toBe('/example/1/abc/?page=1&type=fire');
+    expect(getPath('example', { exampleId: '1', slug: 'abc' }, { page: '1', type: 'fire' }))
+      .toBe('/example/1/abc/?page=1&type=fire');
   });
 
   it('getPath() returns the path with query parameters if an empty object is provided as the 2nd argument and an object of query parameters is provided as the 3rd argument.', () => {
-    expect(getPath('noParams', {}, { page: '1', type: 'fire' })).toBe('/no-params/?page=1&type=fire');
+    expect(getPath('noParams', {}, { page: '1', type: 'fire' }))
+      .toBe('/no-params/?page=1&type=fire');
   });
 
   it('getPath() throws Error if required parameters are missing.', () => {
-    expect(() => getPath('example')).toThrow(missingRequiredParametersMsg('example', nameAndPathMap.example));
+    expect(() => getPath('example'))
+      .toThrow(missingRequiredParametersMsg('example', nameAndPathMap.example));
 
-    expect(() => getPath('example', { slug: 'abc' })).toThrow(missingRequiredParametersMsg('example', nameAndPathMap.example));
+    expect(() => getPath('example', { slug: 'abc' }))
+      .toThrow(missingRequiredParametersMsg('example', nameAndPathMap.example));
 
-    expect(() => getPath('example', {}, { page: '1', type: 'fire' })).toThrow(missingRequiredParametersMsg('example', nameAndPathMap.example));
+    expect(() => getPath('example', {}, { page: '1', type: 'fire' }))
+      .toThrow(missingRequiredParametersMsg('example', nameAndPathMap.example));
   });
 
   it('getPath() throws Error if invalid parameters were provided.', () => {
-    expect(() => getPath('example', { param1: 'a', param2: 'b' })).toThrow(invalidParametersMsg('example', nameAndPathMap.example));
+    expect(() => getPath('example', { param1: 'a', param2: 'b' }))
+      .toThrow(invalidParametersMsg('example', nameAndPathMap.example));
   });
 
   it('getFullPath() returns the path without base url', () => {
-    expect(getFullPath('example', { exampleId: '1', slug: 'abc' }, { page: '1', type: 'fire' })).toBe('/example/1/abc/?page=1&type=fire');
+    expect(getFullPath('example', { exampleId: '1', slug: 'abc' }, { page: '1', type: 'fire' }))
+      .toBe('/example/1/abc/?page=1&type=fire');
+
+    expect(getFullPath('example', { exampleId: '1', slug: 'abc' }))
+      .toBe('/example/1/abc');
+
+    expect(getFullPath('example', { exampleId: '1', slug: 'abc' }, {}))
+      .toBe('/example/1/abc');
+
+    expect(getFullPath('noParams')).toBe('/no-params');
+
+    expect(getFullPath('noParams', { param1: '1', param2: '2' }))
+      .toBe('/no-params');
+
+    expect(getFullPath('noParams', { param1: '1', param2: '2' }, { param1: 'a', param2: 'b' }))
+      .toBe('/no-params/?param1=a&param2=b');
+
+    expect(getFullPath('noParams', {}, { param1: 'a', param2: 'b' }))
+      .toBe('/no-params/?param1=a&param2=b');
   });
 });
 
+// Tests with base url
 const baseUrl = 'http://example.com';
 const {
-  getPath: getPathWithBaseUrl,
-  getFullPath: getFullPathWithBaseUrl,
+  getPath: withoutBaseUrl,
+  getFullPath: WithBaseUrl,
 } = pathManager(nameAndPathMap, baseUrl);
 
 describe('pathManager with the base url test', () => {
   it('getPath() returns a path without the base url.', () => {
-    expect(getPathWithBaseUrl('example', { exampleId: '1', slug: 'abc' }, { page: '1', type: 'fire' })).toBe('/example/1/abc/?page=1&type=fire');
+    expect(withoutBaseUrl('example', { exampleId: '1', slug: 'abc' }))
+      .toBe('/example/1/abc');
+
+    expect(withoutBaseUrl('example', { exampleId: '1', slug: 'abc' }, { page: '1', type: 'fire' }))
+      .toBe('/example/1/abc/?page=1&type=fire');
+
+    expect(withoutBaseUrl('noParams')).toBe('/no-params');
+
+    expect(withoutBaseUrl('noParams', {}, { param1: 'a', param2: 'b' }))
+      .toBe('/no-params/?param1=a&param2=b');
+
+    expect(withoutBaseUrl('noParams', { param1: 'a', param2: 'b' }))
+      .toBe('/no-params');
+
+    expect(withoutBaseUrl('noParams', { param1: 'a', param2: 'b' }, { param1: 'a', param2: 'b' }))
+      .toBe('/no-params/?param1=a&param2=b');
   });
 
-  it('getFullPath() returns a path with the base url.', () => {
-    expect(getFullPathWithBaseUrl('example', { exampleId: '1', slug: 'abc' }, { page: '1', type: 'fire' })).toBe(`${baseUrl}/example/1/abc/?page=1&type=fire`);
+  it('getFullPath() returns the correct path with the base url', () => {
+    expect(WithBaseUrl('noParams')).toBe(`${baseUrl}/no-params`);
+
+    expect(WithBaseUrl('noParams', { param1: 'a', param2: 'b' }))
+      .toBe(`${baseUrl}/no-params`);
+
+    expect(WithBaseUrl('noParams', {}, { param1: '1', param2: '2' }))
+      .toBe(`${baseUrl}/no-params/?param1=1&param2=2`);
+
+    expect(WithBaseUrl('noParams', { param1: 'a', param2: 'b' }, { param1: '1', param2: '2' }))
+      .toBe(`${baseUrl}/no-params/?param1=1&param2=2`);
+
+    expect(WithBaseUrl('example', { exampleId: '1', slug: 'abc' }))
+      .toBe(`${baseUrl}/example/1/abc`);
+
+    expect(WithBaseUrl('example', { exampleId: '1', slug: 'abc' }, {}))
+      .toBe(`${baseUrl}/example/1/abc`);
+
+    expect(WithBaseUrl('example', { exampleId: '1', slug: 'abc' }, { page: '1', type: 'fire' }))
+      .toBe(`${baseUrl}/example/1/abc/?page=1&type=fire`);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "path-kanri",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A utility module for managing paths.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
-import pathManager from './methods';
+import pathManager, { type PathManagerReturnType } from './methods';
+
+export { PathManagerReturnType };
 
 export default pathManager;

--- a/src/methods/index.ts
+++ b/src/methods/index.ts
@@ -117,7 +117,7 @@ const pathManager = <TPathNameAndUriMap extends { [s: string]: unknown; }>(
     if (!paramNames.length) {
       return queryParams
         ? withQueryParams(rawUriStr, queryParams)
-        : withBaseUrl(rawUriStr);
+        : rawUriStr;
     }
 
     // The path contains parameter placeholders but params doesn't provided as the 2nd argument

--- a/src/methods/index.ts
+++ b/src/methods/index.ts
@@ -4,18 +4,31 @@ import { ValueOf, PathParams } from '../types/index';
 // constants
 import { missingRequiredParametersMsg, invalidParametersMsg } from './constants';
 
+export type PathManagerReturnType<TPathNameAndUriMap> = {
+  readonly getPath: (
+    pathName: keyof TPathNameAndUriMap,
+    params?: PathParams,
+    queryParams?: Record<string, string>,
+  ) => string;
+  readonly getFullPath: (
+    pathName: keyof TPathNameAndUriMap,
+    params?: PathParams,
+    queryParams?: Record<string, string>
+  ) => string;
+};
+
 /**
  *
  *
  * @template TPathNameAndUriMap
  * @param {TPathNameAndUriMap} pathNameAndUriMap ex) { name: '/example/{a}/{b}', ... }
- * @param {string} [baseUrl] ex) 'https://api.example.com'
- * @return {*} functions
+ * @param {string} [baseUrl=''] ex) 'https://api.example.com'
+ * @return {PathManagerReturnType<TPathNameAndUriMap>}
  */
 const pathManager = <TPathNameAndUriMap extends { [s: string]: unknown; }>(
   pathNameAndUriMap: TPathNameAndUriMap,
   baseUrl: string = '',
-) => {
+): PathManagerReturnType<TPathNameAndUriMap> => {
   type PathName = keyof typeof pathNameAndUriMap;
   type Uri = ValueOf<typeof pathNameAndUriMap>;
 

--- a/src/methods/index.ts
+++ b/src/methods/index.ts
@@ -18,12 +18,58 @@ export type PathManagerReturnType<TPathNameAndUriMap> = {
 };
 
 /**
+ * Creates a path manager for handling URL paths and parameters.
  *
+ * The pathManager function takes a mapping of path names to URI templates and an optional base URL.
+ * It returns an object with two methods, getPath and getFullPath, which are used to generate URLs
+ * with or without the base URL respectively.
  *
  * @template TPathNameAndUriMap
- * @param {TPathNameAndUriMap} pathNameAndUriMap ex) { name: '/example/{a}/{b}', ... }
- * @param {string} [baseUrl=''] ex) 'https://api.example.com'
+ *  - A mapping type where keys are path names and values are URI templates.
+ *
+ * @param {TPathNameAndUriMap} pathNameAndUriMap
+ * - An object mapping path names to URI templates.
+ * ex) { name: '/example/{a}/{b}', ... }
+ *
+ * @param {string} [baseUrl='']
+ * - An optional base URL to prepend to paths.
+ * ex) 'https://api.example.com'
+ *
  * @return {PathManagerReturnType<TPathNameAndUriMap>}
+ * - An object with getPath and getFullPath methods.
+ *
+ *
+ * Usage Example:
+ *
+ * const paths = {
+ *   example: '/example',
+ *   exampleWithParam: '/another-example/{slug}/{id}',
+ * };
+ *
+ * - Create a path manager with these paths and an optional base URL
+ * const { getPath, getFullPath } = pathManager(paths, 'https://api.example.com');
+ *
+ *
+ * - Generate a path using the 'example' path name
+ * getPath('example');
+ * Returns: '/example'
+ *
+ * getFullPath('example');
+ * Returns: 'https://api.example.com/example'
+ *
+ *
+ * - Generate a path using the 'exampleWithParam' path name and parameters
+ * getPath('exampleWithParam', {slug: 'users', id: '1'});
+ * Returns: '/another-example/users/1'
+ *
+ *
+ * - Generate a path with query parameters
+ * getPath('example', {}, {page: '1', limit: '5'});
+ * Returns: '/example/?page=1&limit=5'
+ *
+ * getFullPath('exampleWithParam', {slug: 'users', id: '1'}, {page: '1', limit: '5'});
+ * Returns 'https://api.example.com/another-example/users/1/?page=1&limit=5'
+ *
  */
 const pathManager = <TPathNameAndUriMap extends { [s: string]: unknown; }>(
   pathNameAndUriMap: TPathNameAndUriMap,

--- a/src/methods/index.ts
+++ b/src/methods/index.ts
@@ -24,16 +24,16 @@ const pathManager = <TPathNameAndUriMap extends { [s: string]: unknown; }>(
    * ex) getParamNamesFromRawUri('/example/{exampleId}/{slug}') -> ['exampleId', 'slug']
    *
    * @param {Uri} rawUri
-   * @return {*}  {string[]}
+   * @return {string[]}
    */
-  const getParamNamesFromRawUri = (rawUri: Uri): string[] => {
+  const getRouteParamNamesFromRawUri = (rawUri: Uri): string[] => {
     const rawUriStr = String(rawUri);
     const paramNamesWithBrackets = rawUriStr.match(/{.+?}/g);
     if (paramNamesWithBrackets === null) return [];
 
     return paramNamesWithBrackets.map((paramNameWithBrackets) => paramNameWithBrackets.replace(/{|}/g, ''));
   };
-  type ParamNames = ReturnType<typeof getParamNamesFromRawUri>;
+  type ParamNames = ReturnType<typeof getRouteParamNamesFromRawUri>;
 
   /**
    * Validate number of parameters and parameter names
@@ -65,7 +65,7 @@ const pathManager = <TPathNameAndUriMap extends { [s: string]: unknown; }>(
    * ex) generateQueryParamsStr({ page: '1', type: 'fire' }) => 'page=1&type=fire'
    *
    * @param {Record<string, string>} paramsObj
-   * @return {*}  {string}
+   * @return {string}
    */
   const generateQueryParamsStr = (paramsObj: Record<string, string>): string => (
     new URLSearchParams(paramsObj).toString()
@@ -75,7 +75,7 @@ const pathManager = <TPathNameAndUriMap extends { [s: string]: unknown; }>(
    * Returns full path
    *
    * @param {string} path
-   * @return {*}  {string}
+   * @return {string}
    */
   const withBaseUrl = (path: string): string => `${baseUrl}${path}`;
 
@@ -101,7 +101,7 @@ const pathManager = <TPathNameAndUriMap extends { [s: string]: unknown; }>(
    *
    * @param {PathName} pathName
    * @param {PathParams} [params]
-   * @return {*}  {string}
+   * @return {string}
    */
   const getPath = (
     pathName: PathName,
@@ -110,7 +110,7 @@ const pathManager = <TPathNameAndUriMap extends { [s: string]: unknown; }>(
   ): string => {
     const rawUri = pathNameAndUriMap[pathName]; // ex) '/example/{exampleId}/{slug}'
 
-    const paramNames = getParamNamesFromRawUri(rawUri); // ex) ['exampleId', 'slug']
+    const paramNames = getRouteParamNamesFromRawUri(rawUri); // ex) ['exampleId', 'slug']
     const rawUriStr = String(rawUri); // This is just for type conversion
 
     // Return if the path doesn't contain any parameter placeholder


### PR DESCRIPTION
# Overview
#3 
Fix getFullPath not to return duplicate base path
- Fix getPath
- Add tests

Other modification
- Declare PathManagerReturnType and export it
- Add detailed documentation of pathManager
- Version 0.2.1 -> 0.2.2

# Changes
Previous getPath()
```typescript
  const getPath = (
    pathName: PathName,
    params?: PathParams,
    queryParams?: Record<string, string>,
  ): string => {
    ...
   
    if (!paramNames.length) {
      return queryParams
        ? withQueryParams(rawUriStr, queryParams)
        : withBaseUrl(rawUriStr); // This was the cause of the bug
    }

    ...
}
```

And fixed not to return with base url
```typescript
  const getPath = (
    pathName: PathName,
    params?: PathParams,
    queryParams?: Record<string, string>,
  ): string => {
    ...
   
    if (!paramNames.length) {
      return queryParams
        ? withQueryParams(rawUriStr, queryParams)
        : rawUriStr; // Return without base url
    }

    ...
}
``` 

# Affected scope
src/index
src/methods
tests

# Note